### PR TITLE
Add safer segfault implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ pub fn main() {
 }
 ```
 
+Or using a segfault implementation that only uses safe code:
+
+```rs
+use segfault;
+
+pub fn main() {
+    segfault::segfault_safe();
+}
+```
+
 ### As Command
 
 ```sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,9 @@ pub fn segfault() -> ! {
         std::hint::unreachable_unchecked()
     }
 }
+
+mod safe;
+
+pub fn segfault_safe() -> ! {
+    safe::segfault()
+}

--- a/src/safe.rs
+++ b/src/safe.rs
@@ -1,0 +1,26 @@
+// No unsafe code here!
+
+// Uses a soundness hole: https://github.com/rust-lang/rust/issues/25860
+
+static UNIT: &'static &'static () = &&();
+
+fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
+
+#[inline(never)]
+fn get_dangling_ref() -> &'static Box<Box<i32>> {
+    let exploit: fn(_, &Box<Box<i32>>) -> &'static Box<Box<i32>> = foo;
+    exploit(UNIT, &Box::new(Box::new(42)))
+}
+
+#[inline(never)]
+fn zero_memory() {
+    std::hint::black_box([0; 128]);
+}
+
+pub fn segfault() -> ! {
+    let dangling = get_dangling_ref();
+    zero_memory();
+    std::hint::black_box(***dangling);
+
+    unreachable!();
+}


### PR DESCRIPTION
The current segfault implementation uses unsafe code. Unsafe code is discouraged as it can be a source of bugs, such as possible memory safety issues.

This PR adds a segfault implementation, `segfault_safe`, which only uses safe Rust. Although this may not be as reliable as the unsafe implementation, the benefit of using no unsafe code is evident.

 Also, README.md has been updated to include an example of this implementation